### PR TITLE
Regex update for relative data:image URLs

### DIFF
--- a/src/default-steps.js
+++ b/src/default-steps.js
@@ -87,7 +87,7 @@ module.exports = [
       log: 'Update relative URLs in CSS.',
       actionType: 'replace',
       selector: 'style',
-      regex: 'url\\(["\']?((?!http(s?))[^\)^"^\']*)["\']?\\)',
+      regex: 'url\\(["\']?((?!http(s?)(?!data:)[^\)^"^\']*)["\']?\\)',
       replace: 'url("$HOST/$1")',
     }],
   },


### PR DESCRIPTION
Updated regex to prevent domain prepending to inline css svg & images.

Before:
.css-selector {background-image:url(https://domain.com/data:image/png;base64...}

After:
.css-selector {background-image:url(data:image/png;base64...}