### PR TITLE
Add customHost and removeDisallowedAttribute action

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,8 @@ Common properties of an action:
 You can also use the following EnvVars in the steps configuration.
 
 - `$URL` <[string]> The URL from the `--url` parameter.
-- `$HOST` <[string]> The host derived from the URL.- `$DOMAIN` <[string]> The domain derived from the URL.
+- `$HOST` <[string]> The host derived from the URL.
+- `$DOMAIN` <[string]> The domain derived from the URL.
 
 For example, you have a step like below:
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Required arguments:
 - `--headless=(true|false)` - Whether to show browser.
 - `--fullPageScreenshot=(true|false*)` - tWhether to save full-page screenshots.
 - `--compareScreenshots=(true|false*)` - Whether to compare original site with converted.
+- `--customHost=HOST` - Use a custom host name when updating relative asset URLs.
 - `--port=PORT_NUMBER` - Port number to use to compare before and after (defaults to 8080)
 - `--verbose` - Display AMP validation errors.
 
@@ -73,25 +74,28 @@ Required arguments:
 
 ```
 # Amplify a page and generate results in /output folder.
-./amp-prototyper http://127.0.0.1:8080
+./amp-prototyper https://thinkwithgoogle.com
 
 # Amplify a page and generate results in /output/test folder.
-./amp-prototyper http://127.0.0.1:8080 --output=test
+./amp-prototyper https://thinkwithgoogle.com --output=test
 
 # Amplify a page with customized steps.
-./amp-prototyper http://127.0.0.1:8080 --steps=custom/mysteps.js
+./amp-prototyper https://thinkwithgoogle.com --steps=custom/mysteps.js
 
 # Amplify a page and display AMP validation details.
-./amp-prototyper http://127.0.0.1:8080 --verbose
+./amp-prototyper https://thinkwithgoogle.com --verbose
 
 # Amplify a page and generate screenshots with specific Device.
-./amp-prototyper http://127.0.0.1:8080 --device='Pixel 2'
+./amp-prototyper https://thinkwithgoogle.com --device='Pixel 2'
 
 # Amplify a page and display browser.
-./amp-prototyper http://127.0.0.1:8080 --headless=false
+./amp-prototyper https://thinkwithgoogle.com --headless=false
 
 # Amplify a page and compare original site with converted.
-./amp-prototyper http://127.0.0.1:8080 --compareScreenshots=true
+./amp-prototyper https://thinkwithgoogle.com --compareScreenshots=true
+
+# Amplify a page that served from localhost and generate results with correct absolute URLs for assets.
+./amp-prototyper https://thinkwithgoogle.com --customHost=https://example.com
 ```
 
 ### Test with a sample HTML.
@@ -183,44 +187,22 @@ Each step follows the structure below.
 
 Step properties:
 
-- `name`
-
-  <string> - Step name.</string>
-
-- `actions`<Array<[Action]()>> - actions to execute.
-- `skip`
-
-  <boolean> - Whether to skip this step.</boolean>
+- `name` <[string]> Step name.
+- `actions` <[Array]<[Action]()>> actions to execute.
+- `skip` <[boolean]> Whether to skip this step.
 
 Common properties of an action:
 
-- `actionType`
-
-  <string> - Action type.</string>
-
-- `log`
-
-  <string> - Message output of this action.</string>
-
-- `waitAfterLoaded`
-
-  <int> - Wait for a specific milliseconds after the page loaded.</int>
+- `actionType` <string]> Action type.
+- `log` <[string]> Message output of this action.
+- `waitAfterLoaded` <[number]> Wait for a specific milliseconds after the page loaded.
 
 ### Environment Variables
 
 You can also use the following EnvVars in the steps configuration.
 
-- `$URL`
-
-  <string> - The URL from the --url parameter.</string>
-
-- `$HOST`
-
-  <string> - The host derived from the URL.</string>
-
-- `$DOMAIN`
-
-  <string> - The domain derived from the URL.</string>
+- `$URL` <[string]> The URL from the `--url` parameter.
+- `$HOST` <[string]> The host derived from the URL.- `$DOMAIN` <[string]> The domain derived from the URL.
 
 For example, you have a step like below:
 
@@ -245,50 +227,36 @@ While running the script with `https://example.com`, it replaces """$HOST""" wit
 
 Set an attribute to a specific element.
 
-- `log`
+- `selector` <[string]> target element.
+- `attribute` <[string]> attribute to ad.
+- `value` <[string]> the attribute value.
 
-  <string> - Message output of this action.</string>
+#### removeAttribute
 
-- `waitAfterLoaded`
+Remove an attribute to a specific element.
 
-  <int> - Wait for a specific milliseconds after the page loaded.</int>
-
+- `selector` <[string]> target element.
+- `attribute` <[string]> attribute to remove.
 #### replace
 
 Use Regex to find and replace in the DOM.
 
-- `selector`
+- `selector` <[string]> target element.
+- `regex` <[string]> Regex string to match.
+- `replace` <[string]> Replace matches with this string.
+#### removeDisallowedAttribute
 
-  <string> - target element.</string>
+Remove an attribute to specific elements based on AMP validation errors.
 
-- `regex`
-
-  <string> - Regex string to match.</string>
-
-- `replace`
-
-  <string> - Replace matches with this string.</string>
-
+- `selector` <[string]> target element.
 #### replaceBasedOnAmpErrors
 
 Use Regex to find and replace in the DOM based on AMP validation errors.
 
-- `selector`
-
-  <string> - target element.</string>
-
-- `ampErrorRegex`
-
-  <string> - Regex string to match for AMP validation errors.</string>
-
-- `regex`
-
-  <string> - Regex string to match.</string>
-
-- `replace`
-
-  <string> - Replace matches with this string.</string>
-
+- `selector` <[string]> target element.
+- `ampErrorRegex` <[string]> Regex string to match for AMP validation errors.
+- `regex` <[string]> Regex string to match.
+- `replace` <[string]> Replace matches with this string.
 For example, in a specific step it has the following AMP validation errors.
 
 ```
@@ -327,34 +295,16 @@ Finally, it uses the revised `regex` to replace the content with `replace` value
 
 Use Regex to find and replace in the DOM. If not found, insert to the destination element.
 
-- `selector`
-
-  <string> - target element.</string>
-
-- `regex`
-
-  <string> - Regex string to match.</string>
-
-- `replace`
-
-  <string> - Replace matches with this string.</string>
-
+- `selector` <[string]> target element.
+- `regex` <[string]> Regex string to match.
+- `replace` <[string]> Replace matches with this string.
 #### insert
 
 Insert a string to the bottom of the destination element. E.g. adding a string to the bottom of the .
 
-- `selector`
-
-  <string> - target element.</string>
-
-- `value`
-
-  <string> - the string to insert.</string>
-
-- `destSelector`
-
-  <string> - destination element.</string>
-
+- `selector` <[string]> target element.
+- `value` <[string]> the string to insert.
+- `destSelector` <[string]> destination element.
 #### move
 
 Move elements to the bottom of the destination element. E.g. moving all
@@ -363,47 +313,37 @@ Move elements to the bottom of the destination element. E.g. moving all
 
  to the bottom of the .
 
-- `selector`
-
-  <string> - target element.</string>
-
-- `destSelector`
-
-  <string> - destination element.</string>
-
+- `selector` <[string]> target element.
+- `destSelector` <[string]> destination element.
 #### appendAfter
 
 Append a string right after a specific element.
 
-- `selector`
-
-  <string> - target element.</string>
-
-- `value`
-
-  <string> - the string to append.</string>
-
+- `selector` <[string]> target element.
+- `value` <[string]> the string to append.
 #### inlineExternalStyles
 
-Collect all external CSS and append a
+Collect all external CSS and append a `<style>` tag with inline CSS.
 
-<style> tag with inline CSS.</p>
-<ul>
-<li><code>selector</code> <string> - target element to append the CSS.</li>
-<li><code>value</code> <string> - the string to append.</li>
-<li><code>excludeDomains</code> &lt;Array<string>&gt; - the array of excluded domains. E.g. <code>[&#39;examples.com&#39;]</code> excludes all CSS loaded from <code>examples.com</code>.</li>
-<li><code>minify</code> <boolean> - whether to minify CSS.</li>
-<li><code>attributes</code> &lt;Array<string>&gt; - add attributes when appending <style> tag.</li>
-</ul>
-<h4 id="removeunusedstyles">removeUnusedStyles</h4>
-<p>Remove unused CSS using <a href="https://github.com/jakubpawlowicz/clean-css">clean-css</a> and <a href="https://github.com/purifycss/purifycss">purifycss</a>.</p>
-<ul>
-<li><code>selector</code> <string> - target element.</li>
-<li><code>value</code> <string> - the string to append.</li>
-</ul>
-<h4 id="customfunc">customFunc</h4>
-<p>Run the action with a custom function. Example:</p>
-<pre><code>  # An action object.
+- `selector` <[string]> target element to append the CSS.
+- `value` <[string]> the string to append.
+- `excludeDomains` <[Array]<[string]>> the array of excluded domains. E.g. [&#39;examples.com&#39;] excludes all CSS loaded from <code>examples.com</code>.
+- `minify` <[boolean]> whether to minify CSS.
+- `attributes` <[Array]<[string]>> add attributes when appending `<style>` tag.
+
+#### removeUnusedStyles
+
+Remove unused CSS using [clean-css](https://github.com/jakubpawlowicz/clean-css) and [purifycss](https://github.com/purifycss/purifycss).
+
+- `selector` <[string]> target element.
+- `value` <[string]> the string to append.
+
+#### customFunc
+
+Run the action with a custom function. Example:
+
+An action object:
+```
   {
     log: &#39;Click a button&#39;,
     actionType: &#39;customFunc&#39;,
@@ -412,15 +352,20 @@ Collect all external CSS and append a
     },
   }],
 },
-</code></pre><p>In the custom function, there are three arguments:</p>
-<ul>
-<li><code>action</code> <ActionObject> - the action object itself.</li>
-<li><code>sourceDom</code> <DOM document> - the raw DOM document object before rendering, as in the View Source in Chrome.</li>
-<li><code>page</code> <puppeteer Page object> - The page object in puppeteer.</li>
-</ul>
-<h3 id="customize-steps">Customize steps</h3>
-<p>To customize your own steps for specific scenarios, create a .js file like below:</p>
-<pre><code>module.exports = [
+```
+
+In the custom function, there are three arguments:
+
+- `action` <[ActionObject]> the action object itself.
+- `sourceDom` <[DOM document]> the raw DOM document object before rendering, as in the View Source in Chrome.
+- `page` <[puppeteer Page object]> The page object in puppeteer.
+
+### Customize steps
+
+To customize your own steps for specific scenarios, create a .js file like below:
+
+```
+module.exports = [
   {
     name: &#39;Remove unwanted styles&#39;,
     actions: [{
@@ -440,12 +385,55 @@ Collect all external CSS and append a
     ...
   }
 ];
-</code></pre><p>Next, run the script with <code>--steps=/path/to/mysteps.js</code>:</p>
-<pre><code># Amplify a page with customized steps.
+```
+
+Next, run the script with `--steps=/path/to/mysteps.js`
+
+```
+# Amplify a page with customized steps.
 ./amp-prototyper http://127.0.0.1:8080 --steps=/path/to/mysteps.js
-</code></pre><h2 id="reference">Reference</h2>
-<ul>
-<li><a href="https://github.com/GoogleChrome/puppeteer">puppeteer</a></li>
-<li><a href="https://github.com/jakubpawlowicz/clean-css">clean-css</a></li>
-<li><a href="https://github.com/purifycss/purifycss">purifycss</a></li>
-</ul>
+```
+
+## Use cases with specific conditions
+
+### Sites with Crawler Protection
+
+Since AMP-prototyper is built with [Puppeteer](https://github.com/GoogleChrome/puppeteer) to fetch a page content, some sites may treat this as a crawler or bot, and thus block the access. You may see a different content (e.g. 404 page or timeout) than the regular page content.
+
+The blocking logic usually resides in the web hosting servers. Hence, there's no easy way to overcome. However, you can try the following options:
+
+#### Option 1 - Set headless=false
+
+Some sites may treat puppeteer activities as crawler if it runs in the headless mode. You can try running with headless off, and puppeteer will show the browser window like browsing by a real user.
+
+```
+# Amplify a page without headless mode.
+./amp-prototyper http://127.0.0.1:8080 --headless=false
+```
+
+#### Option 2 - Serve the page locally
+
+Another option to bypass crawler-protection is to download the page and serve the page from a local web server. (E.g. [http-server](https://www.npmjs.com/package/http-server))
+
+For example, you can save the index page of [ThinkWithGoogle.com](https://www.thinkwithgoogle.com) and serve it locally.  It's recommended to copy the **page source** directly instead of using a browser's Save function to avoid unexpected artifacts by the browser.
+
+Since the host is now `localhost` instead of its original host (www.thinkwithgoogle.com), all relative asset paths would incorrectly end up with localhost. Hence, we need to pass `--customHost` to restore its true remote host for asset URLs.
+
+```
+# Assuming that the index page is saved to ./tmp/web/index.html
+
+npm i http-server -g
+http-server ./tmp/web -p 3000
+```
+
+In a new terminal:
+
+```
+./amp-prototyper http://127.0.0.1:3000 --customHost=https://www.thinkwithgoogle.com
+```
+
+## Reference
+
+[puppeteer](https://github.com/GoogleChrome/puppeteer)
+[clean-css](https://github.com/jakubpawlowicz/clean-css)
+[purifycss](https://github.com/purifycss/purifycss)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amp-prototyper",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "",
   "main": "main.js",
   "scripts": {

--- a/src/cli.js
+++ b/src/cli.js
@@ -17,27 +17,30 @@ Options (*denotes default value if not passed in):
   --verbose\tDisplay AMP validation errors.
   --fullPageScreenshot=(true|false*)\tWhether to save full-page screenshots.
   --compareScreenshots=(true|false*)\tWhether to compare original site with converted.
-  --customHost=HOST\tOverride the hostname with a custom one.
+  --customHost=HOST\tUse a custom host name when updating relative asset URLs.
   --port=PORT_NUMBER\tPort number to use to compare before and after (defaults to 8080).
 
 Examples:
   # AMPlify a page and generate results in /output folder.
-  ./amp-prototyper http://127.0.0.1:8080
+  ./amp-prototyper https://thinkwithgoogle.com
 
   # AMPlify a page and generate results in /output/test folder.
-  ./amp-prototyper http://127.0.0.1:8080 --output=test
+  ./amp-prototyper https://thinkwithgoogle.com --output=test
 
   # AMPlify a page with customized steps.
-  ./amp-prototyper http://127.0.0.1:8080 --steps=custom/mysteps.js
+  ./amp-prototyper https://thinkwithgoogle.com --steps=custom/mysteps.js
 
   # AMPlify a page and display AMP validation details.
-  ./amp-prototyper http://127.0.0.1:8080 --verbose
+  ./amp-prototyper https://thinkwithgoogle.com --verbose
 
   # AMPlify a page and compare original site with converted.
-  ./amp-prototyper http://127.0.0.1:8080 --compareScreenshots=true
+  ./amp-prototyper https://thinkwithgoogle.com --compareScreenshots=true
 
   # AMPlify a page and use a different port.
-  ./amp-prototyper http://127.0.0.1:8080 --port=3000
+  ./amp-prototyper https://thinkwithgoogle.com --port=3000
+
+  # Amplify a page that served from localhost and generate results with correct absolute URLs for assets.
+  ./amp-prototyper https://thinkwithgoogle.com --customHost=https://example.com
   `;
   console.log(usage);
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -21,22 +21,22 @@ Options (*denotes default value if not passed in):
   --port=PORT_NUMBER\tPort number to use to compare before and after (defaults to 8080).
 
 Examples:
-  # AMPlify a page and generate results in /output folder.
+  # Amplify a page and generate results in /output folder.
   ./amp-prototyper https://thinkwithgoogle.com
 
-  # AMPlify a page and generate results in /output/test folder.
+  # Amplify a page and generate results in /output/test folder.
   ./amp-prototyper https://thinkwithgoogle.com --output=test
 
-  # AMPlify a page with customized steps.
+  # Amplify a page with customized steps.
   ./amp-prototyper https://thinkwithgoogle.com --steps=custom/mysteps.js
 
-  # AMPlify a page and display AMP validation details.
+  # Amplify a page and display AMP validation details.
   ./amp-prototyper https://thinkwithgoogle.com --verbose
 
-  # AMPlify a page and compare original site with converted.
+  # Amplify a page and compare original site with converted.
   ./amp-prototyper https://thinkwithgoogle.com --compareScreenshots=true
 
-  # AMPlify a page and use a different port.
+  # Amplify a page and use a different port.
   ./amp-prototyper https://thinkwithgoogle.com --port=3000
 
   # Amplify a page that served from localhost and generate results with correct absolute URLs for assets.

--- a/src/cli.js
+++ b/src/cli.js
@@ -17,6 +17,7 @@ Options (*denotes default value if not passed in):
   --verbose\tDisplay AMP validation errors.
   --fullPageScreenshot=(true|false*)\tWhether to save full-page screenshots.
   --compareScreenshots=(true|false*)\tWhether to compare original site with converted.
+  --customHost=HOST\tOverride the hostname with a custom one.
   --port=PORT_NUMBER\tPort number to use to compare before and after (defaults to 8080).
 
 Examples:

--- a/src/core.js
+++ b/src/core.js
@@ -153,6 +153,27 @@ async function runAction(action, sourceDom, page) {
       message = `${numReplaced} replaced: ${Array.from(matchSet).join(', ')}`;
       break;
 
+    case 'removeDisallowedAttribute': {
+      let ampErrorRegex = 'The attribute \'([^\']*)\' may not appear in tag \'([\\w-]* > )*([\\w-]*)\'';
+      let ampErrorMatches = matchAmpErrors(ampErrors, ampErrorRegex);
+      let matchSet = new Set();
+      let numRemoved = 0;
+
+      ampErrorMatches.forEach(matches => {
+        let attribute = matches[1];
+        let tag = matches[3];
+        matchSet.add(attribute)
+        numRemoved += matches ? matches.length : 0;
+
+        elements = sourceDom.querySelectorAll(tag);
+        elements.forEach((el) => {
+          el.removeAttribute(attribute);
+        });
+      });
+
+      message = `${numRemoved} removed: ${Array.from(matchSet).join(', ')}`;
+      break; }
+
     case 'replace':
       elements = sourceDom.querySelectorAll(action.selector);
       if (!elements.length) throw new Error(`No matched element(s): ${action.selector}`);

--- a/src/core.js
+++ b/src/core.js
@@ -355,6 +355,7 @@ async function amplifyFunc(browser, url, steps, argv, computedDimensions) {
   verbose = argv.hasOwnProperty('verbose');
 
   let device = argv['device'] || 'Pixel 2'
+  let customHost = argv['customHost']
   let consoleOutputs = [];
 
   // Print warnings when missing necessary arguments.
@@ -377,7 +378,7 @@ async function amplifyFunc(browser, url, steps, argv, computedDimensions) {
 
   envVars = {
     '$URL': encodeURI(url),
-    '$HOST': host,
+    '$HOST': customHost || host,
     '$DOMAIN': domain,
   };
 

--- a/src/core.js
+++ b/src/core.js
@@ -150,7 +150,7 @@ async function runAction(action, sourceDom, page) {
           el.innerHTML = el.innerHTML.replace(regex, action.replace);
         });
       });
-      message = `${numReplaced} replaced: ${Array.from(matchSet).join(', ')}`;
+      message = `${numReplaced} replaced: ${[...matchSet].join(', ')}`;
       break;
 
     case 'removeDisallowedAttribute': {
@@ -171,7 +171,7 @@ async function runAction(action, sourceDom, page) {
         });
       });
 
-      message = `${numRemoved} removed: ${Array.from(matchSet).join(', ')}`;
+      message = `${numRemoved} removed: ${[...matchSet].join(', ')}`;
       break; }
 
     case 'replace':

--- a/steps/default-steps.js
+++ b/steps/default-steps.js
@@ -211,11 +211,8 @@ module.exports = [
     name: 'Remove disallowed attributes and tags based on AMP validation result.',
     actions: [{
       log: 'Remove disallowed attributes',
-      actionType: 'replaceBasedOnAmpErrors',
+      actionType: 'removeDisallowedAttribute',
       selector: 'html',
-      ampErrorRegex: 'The attribute \'([^\']*)\' may not appear in tag \'([\\w-]* > )*([\\w-]*)\'',
-      regex: '<($3)\\s+(((?!$1)[\\w-]*="[^"]*"\\s*)*)($1="[^"]*")',
-      replace: '<$1 $3',
     }],
   },
 

--- a/steps/default-steps.js
+++ b/steps/default-steps.js
@@ -189,17 +189,22 @@ module.exports = [
         }
       },
     }, {
+      log: 'Remove attribute sizes in img',
+      actionType: 'removeAttribute',
+      selector: 'img',
+      attribute: 'sizes'
+    }, {
       log: 'Replace img to amp-img',
       actionType: 'replace',
       selector: 'html',
       regex: '<img\\s+((\\w*="[^"]*"\\s*)*)[^>]*/?>',
       replace: '<amp-img $1></amp-img>',
     }, {
-      log: 'Set intrinsic layout',
+      log: 'Set fixed layout',
       actionType: 'setAttribute',
       selector: 'amp-img',
       attribute: 'layout',
-      value: 'intrinsic',
+      value: 'fixed',
     }],
   },
   {
@@ -208,9 +213,9 @@ module.exports = [
       log: 'Remove disallowed attributes',
       actionType: 'replaceBasedOnAmpErrors',
       selector: 'html',
-      ampErrorRegex: 'The attribute \'([^\']*)\' may not appear in tag \'([^\']*)\'',
-      regex: '<($2)\\s+(((?!$1)[\\w-]*="[^"]*"\\s*)*)($1="[^"]*")',
-      replace: '<$1 $2',
+      ampErrorRegex: 'The attribute \'([^\']*)\' may not appear in tag \'([\\w-]* > )*([\\w-]*)\'',
+      regex: '<($3)\\s+(((?!$1)[\\w-]*="[^"]*"\\s*)*)($1="[^"]*")',
+      replace: '<$1 $3',
     }],
   },
 

--- a/test/url-tests.js
+++ b/test/url-tests.js
@@ -7,9 +7,10 @@ const { PNG } = require('pngjs');
 const prototyper = require('../src/core');
 const steps = require('../steps/default-steps');
 const urlsToTest = [
-  //{url:'https://www.thinkwithgoogle.com/', percentage: '0.66'},
+  // Format: {url string, percentage of difference}
+  {url:'https://www.thinkwithgoogle.com/', percentage: '0.00'},
   //{url:'https://www.dulcolax.com/', percentage: '23.57'},
-  {url: 'https://www.ancestrydna.com/', percentage: ''},
+  {url: 'https://www.ancestrydna.com/', percentage: '55.95'},
   // {url: 'https://www.newegg.com/', percentage: ''},
   // {url: 'https://www.libertymutual.com/', percentage: ''},
   // {url: 'https://www.wyndhamhotels.com/', percentage: ''},
@@ -41,7 +42,7 @@ async function tests() {
     let urlWithoutProtocol = url.url.replace(/http(s)?:\/\//ig, '');
     let outputPath = urlWithoutProtocol.replace(/\//ig, '_');
 
-    const passed = await compareImages(`output/${outputPath}/steps/output-step-0.png`, `output/${outputPath}/output-final.png`, `output/${outputPath}/output-temp.png`, computedDimensions[index], url.percentage);
+    const passed = await compareImages(`output/${outputPath}/output-original.png`, `output/${outputPath}/output-final.png`, `output/${outputPath}/output-temp.png`, computedDimensions[index], url.percentage);
     if (passed) {
       pass++;
     }


### PR DESCRIPTION
Multiple updates:
- Add --customHost for restoring remote host name when serving a page content locally.
- Add removeDisallowedAttribute for more granular control than replaceBasedOnAmpErrors.
- Reformat README